### PR TITLE
Set minimum running instances to 1

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,7 +11,7 @@ primary_region = "iad"
   protocol = "tcp"
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [services.concurrency]
     type = "connections"


### PR DESCRIPTION
## Summary
- Changed `min_machines_running` from 0 to 1 in `fly.toml`
- Ensures at least one container instance is always running
- Eliminates cold start delays for incoming requests

## Test plan
- [ ] Verify Fly deployment maintains at least one running instance
- [ ] Confirm auto-scaling still works for traffic spikes
- [ ] Monitor that instances don't all stop during idle periods

🤖 Generated with [Claude Code](https://claude.com/claude-code)