### PR TITLE
Fix enum serialization in format responses

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -30,7 +30,7 @@ def list_creative_formats() -> str:
     Returns:
         JSON array of creative format objects with format_id, name, type, dimensions, etc.
     """
-    formats_data = [fmt.model_dump() for fmt in STANDARD_FORMATS]
+    formats_data = [fmt.model_dump(mode="json") for fmt in STANDARD_FORMATS]
     return json.dumps(formats_data, indent=2)
 
 

--- a/src/creative_agent/api_server.py
+++ b/src/creative_agent/api_server.py
@@ -53,7 +53,7 @@ async def health() -> dict[str, str]:
 @app.get("/formats")
 async def list_formats() -> list[dict[str, Any]]:
     """List all available creative formats."""
-    return [fmt.model_dump() for fmt in STANDARD_FORMATS]
+    return [fmt.model_dump(mode="json") for fmt in STANDARD_FORMATS]
 
 
 @app.get("/formats/{format_id}")
@@ -62,7 +62,7 @@ async def get_format(format_id: str) -> dict[str, Any]:
     fmt = get_format_by_id(format_id)
     if not fmt:
         raise HTTPException(status_code=404, detail=f"Format {format_id} not found")
-    result: dict[str, Any] = fmt.model_dump()
+    result: dict[str, Any] = fmt.model_dump(mode="json")
     return result
 
 

--- a/src/creative_agent/server.py
+++ b/src/creative_agent/server.py
@@ -87,7 +87,7 @@ def list_creative_formats(
         capabilities_enum = [Capability(cap) for cap in AGENT_CAPABILITIES]
 
         # Convert core Format objects to response Format objects
-        response_formats = [ResponseFormat(**fmt.model_dump(exclude_unset=True)) for fmt in formats]
+        response_formats = [ResponseFormat(**fmt.model_dump(mode="json", exclude_unset=True)) for fmt in formats]
 
         response = ListCreativeFormatsResponse(
             status=Status.completed,


### PR DESCRIPTION
## Summary
Fixes #5 - Enum serialization bug in `list_creative_formats` MCP response

## Problem
The creative agent was returning validation errors when calling `list_creative_formats` via MCP. Pydantic enum objects were not being serialized to strings before sending the response, causing errors like:
```
Input should be 'display' [type=enum, input_value=<Type.display: 'display'>, input_type=Type]
```

## Root Cause
Using `model_dump()` without `mode='json'` parameter returns enum fields as Python enum objects instead of their string values:
- `Type.display` instead of `"display"`
- `Category.standard` instead of `"standard"`
- `AssetType.image` instead of `"image"`

## Solution
Changed all `model_dump()` calls to `model_dump(mode='json')` to properly serialize enums to strings.

## Changes
- `src/creative_agent/server.py:90` - Production MCP server
- `src/creative_agent/api_server.py:56,65` - FastAPI HTTP endpoints
- `mcp_server.py:33` - Standalone MCP server

## Testing
- ✅ All smoke tests pass
- ✅ Verified enums serialize as strings
- ✅ JSON serialization works without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)