### PR TITLE
Fix incorrect schema import in list_creative_formats endpoint

### DIFF
--- a/src/creative_agent/server.py
+++ b/src/creative_agent/server.py
@@ -74,12 +74,12 @@ def list_creative_formats(
         )
 
         # Import required types
-        from .schemas_generated._schemas_v1_media_buy_list_creative_formats_response_json import (
+        from .schemas_generated._schemas_v1_creative_list_creative_formats_response_json import (
             Capability,
             CreativeAgent,
             Status,
         )
-        from .schemas_generated._schemas_v1_media_buy_list_creative_formats_response_json import (
+        from .schemas_generated._schemas_v1_creative_list_creative_formats_response_json import (
             Format as ResponseFormat,
         )
 


### PR DESCRIPTION
## Summary
- Corrected import path from `_schemas_v1_media_buy_list_creative_formats_response_json` to `_schemas_v1_creative_list_creative_formats_response_json`
- Resolves server-side error when calling the list creative formats endpoint

## Test plan
- [ ] Verify the API server starts without import errors
- [ ] Test the `/creative/formats` endpoint returns successfully
- [ ] Confirm the response schema matches AdCP v2.4 spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)