### PR TITLE
Add CI link checker and fix README links

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,27 @@
+name: Link Check
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+  schedule:
+    # Run weekly on Monday at 9am UTC to catch links that break over time
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check links with lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Check all markdown files
+          args: --verbose --no-progress '**/*.md'
+          # Fail on broken links
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
     "adcp-creative-agent": {
       "command": "uv",
       "args": ["run", "adcp-creative-agent"],
-      "cwd": "/absolute/path/to/creative-agent/.conductor/jackson-v1"
+      "cwd": "/absolute/path/to/creative-agent"
     }
   }
 }
@@ -135,7 +135,7 @@ Returns all available AdCP creative format specifications.
 
 **Response:** JSON array of AdCP `CreativeFormat` objects.
 
-See the [AdCP Creative Formats specification](https://github.com/anthropics/adcp) for complete schema and field definitions.
+See the [AdCP Creative Formats specification](https://github.com/adcontextprotocol/adcp) for complete schema and field definitions.
 
 ### `build_creative`
 
@@ -327,9 +327,9 @@ supported_macros=COMMON_MACROS + ["VIDEO_ID", "POD_POSITION", "CONTENT_GENRE"]
 ### 6. IAB Specification Links
 
 For standard IAB formats, include specification URLs:
-- Video: `https://iabtechlab.com/standards/video-ad-serving-template-vast/`
+- Video: `https://iabtechlab.com/standards/vast/`
 - Native: `https://iabtechlab.com/standards/openrtb-native/`
-- Display: `https://iabtechlab.com/ad-experiences/display-ad-formats/`
+- Display: `https://iabtechlab.com/standards/iab-new-ad-portfolio-guidelines/`
 
 ## Deployment
 
@@ -495,4 +495,4 @@ MIT License - see LICENSE file
 
 ## Spec Reference
 
-Format specifications from [AdCP Media Buy Protocol](https://adcontextprotocol.org/docs/media-buy/capability-discovery/creative-formats)
+Format specifications from [AdCP Media Buy Protocol](https://adcontextprotocol.org/docs/media-buy/specification)


### PR DESCRIPTION
## Background
Previous conversation identified broken links in the README and a need for automated link checking. This PR addresses both.

## Changes
- **`.github/workflows/link-check.yml`**: New file added. This introduces a GitHub Actions workflow that uses `lychee` to check all markdown links on pull requests, weekly scheduled runs, and manual triggers. The workflow is configured to fail if broken links are found.
- **`README.md`**:
    - Corrected the `cwd` path from `/absolute/path/to/creative-agent/.conductor/jackson-v1` to `/absolute/path/to/creative-agent`.
    - Updated the AdCP GitHub repository link from `https://github.com/anthropics/adcp` to `https://github.com/adcontextprotocol/adcp`.
    - Modified the IAB Video specification link from `https://iabtechlab.com/standards/video-ad-serving-template-vast/` to `https://iabtechlab.com/standards/vast/`.
    - Changed the IAB Display specification link from `https://iabtechlab.com/ad-experiences/display-ad-formats/` to `https://iabtechlab.com/standards/iab-new-ad-portfolio-guidelines/`.
    - Updated the AdCP Media Buy Protocol link from `https://adcontextprotocol.org/docs/media-buy/capability-discovery/creative-formats` to `https://adcontextprotocol.org/docs/media-buy/specification`.

## Testing
- [ ] Verify that the `link-check` workflow triggers on a new pull request.
- [ ] Confirm that the workflow passes when all links are valid.
- [ ] Manually test all updated links in the README to ensure they direct to the correct destinations.
- [ ] (Optional) Introduce a broken link in a markdown file and verify the CI workflow fails.
