### PR TITLE
Update format_id to use structured object

### DIFF
--- a/tests/schemas/v1/_schemas_v1_standard-formats_index_json.json
+++ b/tests/schemas/v1/_schemas_v1_standard-formats_index_json.json
@@ -238,7 +238,10 @@
   "format_extension_guide": {
     "description": "Publishers can extend standard formats using the 'extends' field",
     "example_extension": {
-      "format_id": "publisher_premium_canvas",
+      "format_id": {
+        "agent_url": "https://publisher.example.com/.well-known/adcp/sales",
+        "id": "publisher_premium_canvas"
+      },
       "extends": "foundational_immersive_canvas",
       "publisher": "example_publisher",
       "modifications": {

--- a/tests/validation/test_asset_validation.py
+++ b/tests/validation/test_asset_validation.py
@@ -307,7 +307,10 @@ class TestManifestValidation:
     def test_valid_manifest(self):
         """Valid manifest should pass."""
         manifest = {
-            "format_id": "display_300x250",
+            "format_id": {
+                "agent_url": "https://creative.adcontextprotocol.org",
+                "id": "display_300x250",
+            },
             "assets": {
                 "headline": {
                     "asset_type": "text",
@@ -331,7 +334,10 @@ class TestManifestValidation:
     def test_manifest_with_invalid_asset(self):
         """Manifest with invalid asset should return errors."""
         manifest = {
-            "format_id": "display_300x250",
+            "format_id": {
+                "agent_url": "https://creative.adcontextprotocol.org",
+                "id": "display_300x250",
+            },
             "assets": {
                 "headline": {
                     "asset_type": "text",
@@ -347,7 +353,10 @@ class TestManifestValidation:
     def test_manifest_multiple_errors(self):
         """Manifest with multiple invalid assets should return all errors."""
         manifest = {
-            "format_id": "display_300x250",
+            "format_id": {
+                "agent_url": "https://creative.adcontextprotocol.org",
+                "id": "display_300x250",
+            },
             "assets": {
                 "headline": {
                     "asset_type": "text",
@@ -367,7 +376,10 @@ class TestManifestValidation:
     def test_manifest_without_assets_fails(self):
         """Manifest without assets field should fail."""
         manifest = {
-            "format_id": "display_300x250",
+            "format_id": {
+                "agent_url": "https://creative.adcontextprotocol.org",
+                "id": "display_300x250",
+            },
         }
         errors = validate_manifest_assets(manifest)
         assert len(errors) == 1


### PR DESCRIPTION
## Background
The AdCP specification has been updated to clarify that `format_id` should always be a structured object containing both `agent_url` and `id`.

## Changes
- `tests/schemas/v1/_schemas_v1_standard-formats_index_json.json`: Updated the `example_extension.format_id` to use the structured `{agent_url, id}` format.
- `tests/validation/test_asset_validation.py`: Modified four test cases within `TestManifestValidation` to use the structured `{agent_url, id}` format for `format_id` in test manifests.

## Testing
- [ ] Verify all manifest validation tests pass with the updated `format_id` structure.
- [ ] Confirm that the example extension in the schema now reflects the correct `format_id` structure.
