### PR TITLE
Fix dimensions extraction in storage.py

### DIFF
--- a/src/creative_agent/storage.py
+++ b/src/creative_agent/storage.py
@@ -76,14 +76,16 @@ def generate_preview_html(format_obj: Any, manifest: Any, input_set: Any) -> str
     Returns:
         HTML string ready to display in iframe
     """
-    # Extract dimensions if available
+    # Extract dimensions from first render if available
     width = 300
     height = 250
-    if format_obj.dimensions:
-        parts = format_obj.dimensions.split("x")
-        if len(parts) == 2:
-            width = int(parts[0])
-            height = int(parts[1])
+    if format_obj.renders and len(format_obj.renders) > 0:
+        first_render = format_obj.renders[0]
+        if first_render.dimensions:
+            if first_render.dimensions.width is not None:
+                width = int(first_render.dimensions.width)
+            if first_render.dimensions.height is not None:
+                height = int(first_render.dimensions.height)
 
     # Get primary image asset
     image_url = None


### PR DESCRIPTION
## Background
The code was failing with an `AttributeError` because it incorrectly assumed `format_obj.dimensions` was a string attribute like "300x250". The actual dimensions are nested within the `renders` field of the `Format` object.

## Changes
- **`src/creative_agent/storage.py`**:
    - Modified dimension extraction logic.
    - Now accesses dimensions from `format_obj.renders[0].dimensions.width` and `format_obj.renders[0].dimensions.height`.
    - Added checks for the existence of `renders` and `dimensions` before accessing them.
    - Retains the default 300x250 dimensions if no renders or dimensions are found.

## Testing
- [ ] Verify preview_creative test passes.
- [ ] Test with formats that have dimensions defined in `renders` (e.g., `display_336x280_html`).
- [ ] Test with formats that do not have `renders` defined.
