### PR TITLE
Fix asset_type in creative manifest prompts

### DIFF
--- a/src/creative_agent/server.py
+++ b/src/creative_agent/server.py
@@ -666,9 +666,9 @@ After generating the images, output ONLY a JSON creative manifest with this stru
   "format_id": "{output_format_id}",
   "assets": {{
     // Map each required asset_id to appropriate asset data
-    // For images: {{"asset_type": "image", "url": "GENERATED_IMAGE_PLACEHOLDER", "width": X, "height": Y, "format": "png"}}
-    // For text: {{"asset_type": "text", "content": "..."}}
-    // For urls: {{"asset_type": "url", "url": "..."}}
+    // For images: {{"url": "GENERATED_IMAGE_PLACEHOLDER", "width": X, "height": Y, "format": "png"}}
+    // For text: {{"content": "..."}}
+    // For urls: {{"url": "..."}}
   }},
   "metadata": {{
     "generated_by": "AdCP Creative Agent",
@@ -689,8 +689,8 @@ Generate a JSON creative manifest with the following structure:
   "format_id": "{output_format_id}",
   "assets": {{
     // Map each required asset_id to appropriate asset data
-    // For text: {{"asset_type": "text", "content": "..."}}
-    // For urls: {{"asset_type": "url", "url": "..."}}
+    // For text: {{"content": "..."}}
+    // For urls: {{"url": "..."}}
   }},
   "metadata": {{
     "generated_by": "AdCP Creative Agent",


### PR DESCRIPTION
## Background
The ADCP spec no longer requires `asset_type` in creative manifest assets. This change corrects AI prompts that were incorrectly including it.

## Changes
- Modified AI prompts in `src/creative_agent/server.py` (lines 669-671 and 692-693) to remove the `asset_type` field from example asset structures.
  - **Before**: `{"asset_type": "image", "url": "GENERATED_IMAGE_PLACEHOLDER", ...}`
  - **After**: `{"url": "GENERATED_IMAGE_PLACEHOLDER", ...}`

## Testing
- [ ] Manually preview a creative that requires image, text, and URL assets.
- [ ] Verify that no `asset_type` is present in the generated manifest.
