### PR TITLE
Remove Gemini API key param, use env var

### DIFF
--- a/src/creative_agent/schemas/build.py
+++ b/src/creative_agent/schemas/build.py
@@ -39,8 +39,6 @@ class BuildCreativeRequest(BaseModel):
     assets: list[AssetReference] = []
     preview_options: PreviewOptions | None = None
     finalize: bool = False
-    # User must provide their own Gemini API key
-    gemini_api_key: str | None = None
 
 
 class CreativeOutput(BaseModel):

--- a/src/creative_agent/server.py
+++ b/src/creative_agent/server.py
@@ -417,7 +417,6 @@ def build_creative(
     target_format_id: str | dict[str, Any],
     creative_manifest: dict[str, Any] | None = None,
     message: str | None = None,
-    gemini_api_key: str | None = None,
 ) -> ToolResult:
     """Transform or generate a creative manifest using AI.
 
@@ -425,10 +424,12 @@ def build_creative(
         target_format_id: Format ID to generate (string or FormatId object with agent_url and id)
         creative_manifest: Source creative manifest with input assets (e.g., promoted_offerings for generative formats)
         message: Natural language instructions for transformation or generation
-        gemini_api_key: User's Gemini API key for AI generation
 
     Returns:
         ToolResult with creative_manifest in structured_content
+
+    Note:
+        Requires GEMINI_API_KEY environment variable to be set for generative formats.
     """
     try:
         # Parse target_format_id
@@ -474,9 +475,10 @@ def build_creative(
                     structured_content={"error": error_msg},
                 )
 
-            # Validate gemini_api_key is provided for generation
+            # Get Gemini API key from environment
+            gemini_api_key = os.getenv("GEMINI_API_KEY")
             if not gemini_api_key:
-                error_msg = "gemini_api_key is required for generative formats. Get one at https://ai.google.dev/"
+                error_msg = "GEMINI_API_KEY environment variable is required for generative formats. Get a key at https://ai.google.dev/"
                 return ToolResult(
                     content=[TextContent(type="text", text=f"Error: {error_msg}")],
                     structured_content={"error": error_msg},


### PR DESCRIPTION
## Background
The `gemini_api_key` parameter was not compliant with the ADCP spec. API keys should be managed via environment variables for creative agents.

## Changes
- `src/creative_agent/schemas/build.py`: Removed `gemini_api_key` from `BuildCreativeRequest` schema.
- `src/creative_agent/server.py`: Removed `gemini_api_key` parameter from `build_creative` function. The function now reads the Gemini API key from the `GEMINI_API_KEY` environment variable. Added a more informative error message if the environment variable is not set.

## Testing
- [ ] Call `build_creative` without `GEMINI_API_KEY` set, verify error message.
- [ ] Call `build_creative` with `GEMINI_API_KEY` environment variable set, verify successful execution.
- [ ] Verify the `target_format_id` parameter is still correctly handled.
