### PR TITLE
Fix null field serialization in format responses

### DIFF
--- a/src/creative_agent/api_server.py
+++ b/src/creative_agent/api_server.py
@@ -53,7 +53,7 @@ async def health() -> dict[str, str]:
 @app.get("/formats")
 async def list_formats() -> list[dict[str, Any]]:
     """List all available creative formats."""
-    return [fmt.model_dump(mode="json") for fmt in STANDARD_FORMATS]
+    return [fmt.model_dump(mode="json", exclude_none=True) for fmt in STANDARD_FORMATS]
 
 
 @app.get("/formats/{format_id}")
@@ -68,7 +68,7 @@ async def get_format(format_id: str) -> dict[str, Any]:
     fmt = get_format_by_id(fmt_id)
     if not fmt:
         raise HTTPException(status_code=404, detail=f"Format {format_id} not found")
-    result: dict[str, Any] = fmt.model_dump(mode="json")
+    result: dict[str, Any] = fmt.model_dump(mode="json", exclude_none=True)
     return result
 
 

--- a/src/creative_agent/server.py
+++ b/src/creative_agent/server.py
@@ -121,7 +121,7 @@ def list_creative_formats(
         capabilities_enum = [Capability(cap) for cap in AGENT_CAPABILITIES]
 
         # Convert core Format objects to response Format objects
-        response_formats = [ResponseFormat(**fmt.model_dump(mode="json", exclude_unset=True)) for fmt in formats]
+        response_formats = [ResponseFormat(**fmt.model_dump(mode="json", exclude_none=True)) for fmt in formats]
 
         response = ListCreativeFormatsResponse(
             formats=response_formats,
@@ -148,7 +148,7 @@ def list_creative_formats(
 
         return ToolResult(
             content=[TextContent(type="text", text=message)],
-            structured_content=response.model_dump(mode="json"),
+            structured_content=response.model_dump(mode="json", exclude_none=True),
         )
     except ValueError as e:
         error_response = {"error": f"Invalid input: {e}"}
@@ -322,7 +322,7 @@ def preview_creative(
 
         return ToolResult(
             content=[TextContent(type="text", text=message)],
-            structured_content=response.model_dump(mode="json"),
+            structured_content=response.model_dump(mode="json", exclude_none=True),
         )
     except ValueError as e:
         error_msg = f"Invalid input: {e}"
@@ -409,7 +409,7 @@ def _generate_preview_variant(
         input=input_echo,
     )
 
-    return preview.model_dump(mode="json")
+    return preview.model_dump(mode="json", exclude_none=True)
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

Fixes schema validation failures in `list_creative_formats` and related endpoints by properly handling optional fields during JSON serialization.

## Problem

The ADCP client was reporting schema validation errors for fields that were explicitly set to `null` in the JSON response:

```
Schema validation: formats.0.preview_image: Expected string, received null
Schema validation: formats.0.example_url: Expected string, received null
Schema validation: formats.0.renders.0.dimensions.min_width: Expected number, received null
...
```

Per the ADCP specification, optional fields should either:
- Have valid values (string, number, object, array), OR
- Be completely omitted from the JSON

## Solution

Changed all `model_dump(mode="json")` calls to use `exclude_none=True` instead of `exclude_unset=True`. This ensures that fields with `None` values are omitted from the serialized output rather than appearing as explicit `null` values.

## Changes

- `src/creative_agent/server.py`: Updated 4 serialization calls
- `src/creative_agent/api_server.py`: Updated 2 serialization calls

## Testing

- ✅ All integration tests pass (20/20)
- ✅ All schema compliance tests pass (6/6)
- ✅ Verified no null fields in serialized output
- ✅ Pydantic validation passes for all 38 standard formats

## Impact

This fix ensures full compliance with the ADCP specification and resolves validation errors when using the `@adcp/client` CLI tool.