### PR TITLE
Upgrade to adcp 2.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "boto3>=1.35.0",
     "markdown>=3.6",
     "bleach>=6.3.0",
-    "adcp>=2.12.0",  # Official ADCP Python client with template format support
+    "adcp>=2.13.0",  # Official ADCP Python client with template format support
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,7 @@ wheels = [
 
 [[package]]
 name = "adcp"
-version = "2.12.0"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "a2a-sdk" },
@@ -34,9 +34,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/e5/c0582bcc0b0bf0caf30ca32c5124710c7091934efbac4b36d8983869a27b/adcp-2.12.0.tar.gz", hash = "sha256:b2b5035ffc013c4f9e82115f076538a5528a4fc1f6f5435702b4e2562370f8cf", size = 153689, upload-time = "2025-11-22T21:56:24.488Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/d9/45a25b65b4959c23624ca053dbbfaa5647f4bb1bc87aa863971435d92107/adcp-2.13.0.tar.gz", hash = "sha256:33e147d0b747d66303018add681f659c79e60d693806255b7f811136e4bc21bf", size = 160210, upload-time = "2025-12-07T12:44:48.35Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/e3/3f4293096d5a8372ccc820f345635d87770e608ee20ac1e966dd246e76f3/adcp-2.12.0-py3-none-any.whl", hash = "sha256:9ed5a14ae52d9150177af676713f0caf4269b08d4f8d2783e2b17c00bb2575ae", size = 190486, upload-time = "2025-11-22T21:56:22.815Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a6/589d7a9f37dbc1c2e10aa7993159e467347de7065984ad4059779a1be375/adcp-2.13.0-py3-none-any.whl", hash = "sha256:617a394e189a09f54cfb6ae5b431937f2a7c90a44fa2e8b63012cda334c0bc85", size = 193254, upload-time = "2025-12-07T12:44:46.886Z" },
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "adcp", specifier = ">=2.12.0" },
+    { name = "adcp", specifier = ">=2.13.0" },
     { name = "bleach", specifier = ">=6.3.0" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "fastapi", specifier = ">=0.100.0" },


### PR DESCRIPTION
Upgrades the adcp dependency from 2.12.0 to 2.13.0. All 257 tests pass with the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)