### PR TITLE
Fix: Convert relative imports to absolute imports in server.py

### DIFF
--- a/src/creative_agent/server.py
+++ b/src/creative_agent/server.py
@@ -14,14 +14,14 @@ from fastmcp.tools.tool import ToolResult
 from mcp.types import TextContent
 from pydantic import AnyUrl
 
-from .data.standard_formats import (
+from creative_agent.data.standard_formats import (
     AGENT_CAPABILITIES,
     AGENT_NAME,
     AGENT_URL,
     filter_formats,
     get_format_by_id,
 )
-from .schemas import (
+from creative_agent.schemas import (
     ListCreativeFormatsResponse,
     PreviewCreativeRequest,
 )
@@ -223,7 +223,7 @@ def _handle_single_preview(
     output_format: str,
 ) -> ToolResult:
     """Handle a single preview request."""
-    from .schemas.manifest import PreviewInput
+    from creative_agent.schemas.manifest import PreviewInput
 
     # Parse inputs if provided
     inputs_obj: list[PreviewInput] | None = None
@@ -268,7 +268,7 @@ def _handle_single_preview(
             )
 
     # Validate manifest assets
-    from .validation import validate_manifest_assets
+    from creative_agent.validation import validate_manifest_assets
 
     validation_errors = validate_manifest_assets(
         request.creative_manifest,
@@ -294,7 +294,7 @@ def _handle_single_preview(
         ]
 
     # Generate previews for each input set
-    from .storage import generate_preview_html, upload_preview_html
+    from creative_agent.storage import generate_preview_html, upload_preview_html
 
     previews = []
     for input_set in request.inputs:
@@ -720,7 +720,7 @@ Return ONLY the JSON manifest, no additional text."""
             output_manifest = json.loads(manifest_json)
 
             # Validate against output format
-            from .validation import validate_manifest_assets
+            from creative_agent.validation import validate_manifest_assets
 
             validation_errors = validate_manifest_assets(
                 output_manifest,


### PR DESCRIPTION
When running `fastmcp dev src/creative_agent/server.py` directly, Python doesn't treat the file as part of a package, causing relative imports to fail with "ImportError: attempted relative import with no known parent package".

Changed all relative imports to absolute imports:
- .data.standard_formats → creative_agent.data.standard_formats
- .schemas → creative_agent.schemas
- .schemas.manifest → creative_agent.schemas.manifest
- .validation → creative_agent.validation
- .storage → creative_agent.storage

This ensures the server works both as a module entry point and when run directly with fastmcp dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)